### PR TITLE
debian/changelog: Prepare for NMU

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
-libu2f-server (1.0.1-2) unstable; urgency=medium
+libu2f-server (1.0.1-1+nmu1) unstable; urgency=medium
 
   * Fix dependencies (Closes: 820690).
+  * Non-maintainer upload.
 
- --
+ -- Nicolas Braud-Santoni <nicolas@braud-santoni.eu>  Thu, 02 Jun 2016 00:06:28 +0200
 
 libu2f-server (1.0.1-1) unstable; urgency=medium
 

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 
+include /usr/share/dpkg/pkg-info.mk
+
 %:
 	dh $@ --parallel --with autoreconf
 
@@ -16,3 +18,10 @@ override_dh_auto_clean:
 
 override_dh_compress:
 	dh_compress -Xu2f-server.pdf
+
+
+gen-orig-source:
+	git archive --format=tar.gz                                     \
+		--prefix=$(DEB_SOURCE)-$(DEB_VERSION_UPSTREAM)/         \
+		upstream/$(subst ~,_,$(DEB_VERSION_UPSTREAM))           \
+		-o ../$(DEB_SOURCE)_$(DEB_VERSION_UPSTREAM).orig.tar.gz


### PR DESCRIPTION
Follow-up on #1, fix the Debian changelog in a way that is suitable for a NMU.
